### PR TITLE
Fix SearchRepository.addSearch, make  where inside callback

### DIFF
--- a/src/Repositories/SearchRepository.php
+++ b/src/Repositories/SearchRepository.php
@@ -4,78 +4,79 @@ namespace Witty\LaravelTableView\Repositories;
 
 use Request;
 
-class SearchRepository 
+class SearchRepository
 {
-	/**
-	 * @var string
-	 */
-	private $searchQuery;
+    /**
+     * @var string
+     */
+    private $searchQuery;
 
-	/**
-	 * @var array
-	 */
-	private $searchFields = [];
+    /**
+     * @var array
+     */
+    private $searchFields = [];
 
-	/**
-	 * @return void
-	 */
-	public function __construct()
-	{
-		$this->searchQuery = Request::input('q', '');
-	}
+    /**
+     */
+    public function __construct()
+    {
+        $this->searchQuery = Request::input('q', '');
+    }
 
-	/**
+    /**
      * @param mixed $searchField
-     * @return void
      */
-	public function field($searchField)
-	{
-		if ( is_string($searchField) )
-		{
-			$this->searchFields[] = $searchField;
-		}
-		else if ( is_array($searchField) )
-		{
-			$this->searchFields = array_merge($this->searchFields, $searchFields);
-		}
-	}
+    public function field($searchField)
+    {
+        if (is_string($searchField)) {
+            $this->searchFields[] = $searchField;
+        } elseif (is_array($searchField)) {
+            $this->searchFields = array_merge($this->searchFields, $searchFields);
+        }
+    }
 
-	/**
-     * @return boolean
+    /**
+     * @return bool
      */
-	public function isEnabled()
-	{
-		return (bool) count($this->searchFields);
-	}
+    public function isEnabled()
+    {
+        return (bool) count($this->searchFields);
+    }
 
-	/**
+    /**
      * @return string
      */
-	public function queryString()
-	{
-		return $this->searchQuery;
-	}
+    public function queryString()
+    {
+        return $this->searchQuery;
+    }
 
-	/**
-     * Filter data collection for search query if there is one
+    /**
+     * Filter data collection for search query if there is one.
      *
      * @param \Illuminate\Database\Eloquent\Collection $dataCollection
      * @param array
+     *
      * @return \Illuminate\Database\Eloquent\Collection
      */
-	public function addSearch($dataCollection)
-	{
-		if ( ! $this->searchQuery ) return $dataCollection;
+    public function addSearch($dataCollection)
+    {
+        if (! $this->searchQuery) {
+            return $dataCollection;
+        }
 
-		$i = 0;
-		foreach ($this->searchFields as $searchableProperty)
-		{
-			$whereClause = ($i === 0) ? 'where' : 'orWhere';
+        $dataCollection = $dataCollection->where(function ($q) {
+            $i = 0;
 
-			$dataCollection = $dataCollection->{$whereClause}($searchableProperty, 'LIKE', "%{$this->searchQuery}%");
-			$i++;
-		}
+            foreach ($this->searchFields as $searchableProperty) {
+                $whereClause = ($i === 0) ? 'where' : 'orWhere';
 
-		return $dataCollection;
-	}
+                $q->{$whereClause}($searchableProperty, 'LIKE', "%{$this->searchQuery}%");
+
+                ++$i;
+            }
+        });
+
+        return $dataCollection;
+    }
 }


### PR DESCRIPTION
This push make all search fields inside where callback, to avoid return result with softDeleted query 

``` php
    $dataCollection = $dataCollection->where(function ($q) {
            $i = 0;

            foreach ($this->searchFields as $searchableProperty) {
                $whereClause = ($i === 0) ? 'where' : 'orWhere';

                $q->{$whereClause}($searchableProperty, 'LIKE', "%{$this->searchQuery}%");

                ++$i;
            }
        });
```

Without this patch our query would be like this

``` sql
select * from `transaction_references` where `transaction_references`.`deleted_at` is null and `name` LIKE '%bank%' or `slug` LIKE '%bank%' order by `id` desc limit 10 offset 0
```

And with this patch would result right query with `()`

``` sql
select * from `transaction_references` where `transaction_references`.`deleted_at` is null and (`name` LIKE '%bank%' or `slug` LIKE '%bank%') order by `id` desc limit 10 offset 0
```
